### PR TITLE
Allow for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+  - 5.5
   - 5.6
   - 7.0
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=5.5.0",
         "guzzlehttp/guzzle": "^6.1",
         "Respect/Validation": "~1"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "Respect/Validation": "~1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.1",
+        "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.4"
     },
     "autoload-dev": {


### PR DESCRIPTION
Hey there!

There's nothing in the repo specific to PHP 5.6 save for PHPUnit 5.1. I ran the tests and they all pass, so 5.5 is also suported :+1: 

Here's the tests: https://travis-ci.org/nathanielks/newrelic