### PR TITLE
Allow classes to be partially monitored

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,42 @@ New Relic Transaction Library
 
 Use this library to report background jobs or long running scripts to New Relic APM.
 
+## Examples
+
 ```php
 <?php
 
-namespace EmailConsumer;
+namespace Consumers;
 
-class EmailConsumer
+class Email
 {
     public function sendEmail($recipient, $body, $header)
     {
         //Send email
     }
+
+    public function beforePerform()
+    {
+        //Before Hook
+    }
+
+    public function perform()
+    {
+        //Perform a job
+    }
+
+    public function afterPerform()
+    {
+        //After Hook
+    }
 }
 
-namespace A\B;
+namespace Foo\Bar;
 
 use EasyTaxi\NewRelic;
-use EmailConsumer;
+use Consumers;
 
-$consumer = new EmailConsumer();
+$consumer = new Consumers\Email();
 
 while (true) {
     $transactionConfig = new NewRelic\Config\TransactionConfig();
@@ -35,10 +52,28 @@ while (true) {
     $transactionConfig->transactionName = 'consumer::sendEmail';
     $consumerMonitored = new NewRelic\Transaction($consumer, $transactionConfig);
     $consumerMonitored->sendEmail('Spock', 'James', 'Tiberius');
+
+    $transactionConfig->monitoredMethodName = 'perform';
+    $consumerMonitored->beforePerform();
+    $consumerMonitored->perform();
+    $consumerMonitored->afterPerform();
 }
 ```
 
 > You MUST have an agent configured and running on the server
+
+## Configuration options
+
+Use `TransactionConfig` class to personalize your job.
+
+- You can use `transactionName` field to specify the name of each transactions
+    > Defaults to `index.php` if not specified
+
+- You can use `applicationName` field to specify the name your application
+    > Defaults to `PHP Application` if not specified
+
+- You can use `monitoredMethodName` field to specify only one method to be monitored
+    > If not defined every call to a method will be considered one transaction
 
 New Relic Insights Library
 ==========================

--- a/src/Config/TransactionConfig.php
+++ b/src/Config/TransactionConfig.php
@@ -6,4 +6,5 @@ class TransactionConfig
 {
     public $transactionName = 'index.php';
     public $applicationName = 'PHP Application';
+    public $monitoredMethodName;
 }

--- a/tests/Stub/Foo.php
+++ b/tests/Stub/Foo.php
@@ -13,4 +13,9 @@ class Foo
     {
         throw $exception;
     }
+
+    public function foo($argument = null)
+    {
+        return $argument;
+    }
 }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -16,15 +16,19 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     public static $exception;
     public static $applicationName;
     public static $extensionAvailable;
+    public static $transactionsCount;
+
+    private $config;
 
     public function setUp()
     {
-        $config = new TransactionConfig();
-        $config->applicationName = 'Panthro';
-        $config->transactionName = 'Jaga';
+        $this->config = new TransactionConfig();
+        $this->config->applicationName = 'Panthro';
+        $this->config->transactionName = 'Jaga';
         self::$extensionAvailable = true;
-        $this->transaction = new Transaction(new Foo(), $config);
+        $this->transaction = new Transaction(new Foo(), $this->config);
         self::$endTransaction = false;
+        self::$transactionsCount = 0;
     }
 
     public function testHasAbilityToSetApplicationName()
@@ -138,11 +142,22 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
 
         new Transaction(new \StdClass, new TransactionConfig());
     }
+
+    public function testTransactioIsStartedOnlyForDesiredMethodCall()
+    {
+        $this->config->monitoredMethodName = 'foo';
+
+        $this->transaction->bar();
+        $this->transaction->foo();
+
+        $this->assertEquals(1, self::$transactionsCount);
+    }
 }
 
 function newrelic_start_transaction($appName)
 {
     TransactionTest::$applicationNameStarted = $appName;
+    TransactionTest::$transactionsCount++;
 }
 
 function newrelic_name_transaction($transactionName)


### PR DESCRIPTION
There are some bad designs that use multiple calls to a consumer class
trying to ask the class what to do instead of tell it to perform the job
and this lead to call __call multiple times generating one transaction
per method called.

Now you can specify the name of the method you want to spy. For backward
compatibility the method name is empty maitaining same behavior as before
which is transact every method call.